### PR TITLE
storing files list in temporary file

### DIFF
--- a/lib/parallelizer.js
+++ b/lib/parallelizer.js
@@ -29,7 +29,7 @@ Parallelizer.prototype.exec = function(task, target) {
   // }
 
   lpad.stdout('    ');
-  var ok = true;.
+  var ok = true;
   var inc = 0;
   async.forEach(splittedFilesSrc, function(filesSrc, next) {
     var filesOption = '--grunt-parallelize-child-filesSrc=' + filesSrc.join(path.delimiter);

--- a/lib/parallelizer.js
+++ b/lib/parallelizer.js
@@ -29,12 +29,23 @@ Parallelizer.prototype.exec = function(task, target) {
   // }
 
   lpad.stdout('    ');
-  var ok = true;
+  var ok = true;.
+  var inc = 0;
   async.forEach(splittedFilesSrc, function(filesSrc, next) {
     var filesOption = '--grunt-parallelize-child-filesSrc=' + filesSrc.join(path.delimiter);
+    var taskArgs = [['parallelize', task, target].join(':')];
+    var argsToPass = taskArgs.concat(this.grunt_.option.flags(), filesOption);
+
+    if (filesOption.length > 256) {
+      var fileTaskArgs = path.join('tmp', 'parallelize', task, target, String(inc));
+      this.grunt_.file.mkdir(path.dirname(fileTaskArgs));
+      this.grunt_.file.write(fileTaskArgs, filesSrc.join(path.delimiter));
+      argsToPass = taskArgs.concat(this.grunt_.option.flags(), '--grunt-parallelize-child-filesFrom=' + fileTaskArgs);
+    }
+    inc += 1;
     var cp = this.grunt_.util.spawn({
       grunt: true,
-      args: [['parallelize', task, target].join(':')].concat(this.grunt_.option.flags(), filesOption),
+      args: argsToPass,
       opts: spawnOptions
     }, function(err, result, code) {
       if ((err || code > 0)) {

--- a/tasks/parallelize.js
+++ b/tasks/parallelize.js
@@ -27,8 +27,12 @@ module.exports = function(grunt) {
       executor.exec(grunt, this.data, task, this.async());
     } else {
       var childFilesSrcOption = grunt.option('grunt-parallelize-child-filesSrc');
+	  var childFilesFromOption = grunt.option('grunt-parallelize-child-filesFrom');
       if (childFilesSrcOption) {
         // this is spawned child process
+        taskRunner(grunt, childFilesSrcOption, task, target);
+      } else if (childFilesFromOption) {
+        childFilesSrcOption = grunt.file.read(childFilesFromOption);
         taskRunner(grunt, childFilesSrcOption, task, target);
       } else {
         var parallelizer = new Parallelizer(grunt, this);


### PR DESCRIPTION
When file list too large we can't pass via arguments flag, so we should store it elsewhere.