### PR TITLE
Update task runner to support the task cwd config;

### DIFF
--- a/lib/taskrunner.js
+++ b/lib/taskrunner.js
@@ -14,6 +14,11 @@ module.exports = function(grunt, childFilesSrcOption, task, target) {
   } else if (type === 'object') {
     if (_.contains(['string', 'array'], kindOf(config.src))) {
       // Compact Format
+      if (kindOf(config.cwd) !== 'undefined') {
+        childFilesSrc = childFilesSrc.map(function (file) {
+          return file.replace(config.cwd, '');
+        });
+      }
       grunt.config(configPath.concat('src'), childFilesSrc);
     } else if ('array' === kindOf(config.files)) {
       // Files Array Format


### PR DESCRIPTION
Fixes the following scenario:

Original task config:

```
{ expand: true,
      cwd: 'some/path/',
      src: [ '**/*.less' ],
      dest: '...',
      ext: '.css' }
```

Currently the task runner sets the following config:

```
{ expand: true,
      cwd: 'some/path/',
      src: [ 'some/path/file.less' ],
      dest: '...',
      ext: '.css' }
```

With this fix:

```
{ expand: true,
      cwd: 'some/path/',
      src: [ 'file.less' ],
      dest: '...',
      ext: '.css' }
```