### PR TITLE
Use updated license spec for package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,7 @@
   "bugs": {
     "url": "https://github.com/teppeis/grunt-parallelize/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/teppeis/grunt-parallelize/blob/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "main": "./tasks/parallelize.js",
   "engines": {
     "node": ">= 0.10.0"


### PR DESCRIPTION
See https://docs.npmjs.com/files/package.json#license

This will fix warnings when installing this package