### PR TITLE
Change internal file format

### DIFF
--- a/lib/parallelizer.js
+++ b/lib/parallelizer.js
@@ -93,43 +93,49 @@ Parallelizer.prototype.getProcesses_ = function(task, target) {
 };
 
 Parallelizer.prototype.getSplittedFilesSrc_ = function(task, target) {
-  var filesSrc = this.getNormalizedFilesSrc_(task, target);
+  var files = this.getNormalizedFiles_(task, target);
   var processes = this.getProcesses_(task, target);
+
+  // if any file objects have a destination, can assume that not all src files
+  // can be merged into single list
+  if (this.hasDest_(files)) {
+    return this.splitArray_(files, processes);
+  } else {
+    var filesSrc = _(files).chain().pluck('src').flatten().uniq().value();
+    return this.splitArray_(filesSrc, processes).map(function(src) {
+      return {
+        src: src
+      };
+    });
+  }
+};
+
+Parallelizer.prototype.getNormalizedFiles_ = function(task, target) {
+  var configPath = [task, target];
+  var config = this.grunt_.config(configPath);
+  return this.grunt_.task.normalizeMultiTaskFiles(config);
+};
+
+Parallelizer.prototype.hasDest_ = function(files) {
+  return files.some(function(fileObj) {
+    return fileObj.dest !== undefined;
+  });
+};
+
+Parallelizer.prototype.splitArray_ = function(arr, processes) {
   if (processes < 0) {
     throw new Error('"processes" option shoud be positive');
   } else if (!processes) {
     return [];
   }
-  var remain = filesSrc.length % processes;
-  var per = (filesSrc.length - remain) / processes;
-  var splittedFilesSrc = [];
-  while (filesSrc.length) {
-    splittedFilesSrc.push(filesSrc.splice(0, remain-- > 0 ? per + 1 : per));
-  }
-  return splittedFilesSrc;
-};
 
-Parallelizer.prototype.getNormalizedFilesSrc_ = function(task, target) {
-  var configPath = [task, target];
-  var config = this.grunt_.config(configPath);
-  var files = this.grunt_.task.normalizeMultiTaskFiles(config);
-  // if any file objects have a destination, can assume that not all src files
-  // can be merged into single list
-  var hasDest = false;
-  files.forEach(function (fileObj) {
-    if (fileObj.dest !== undefined){ hasDest = true; }
-  });
-  var normalizedFiles;
-  if (hasDest){
-    normalizedFiles = files;
-  } else {
-    normalizedFiles = _(files).chain().pluck('src').flatten().uniq().value();
-    normalizedFiles = normalizedFiles.map(function (srcFile) {
-      return { src: srcFile, };
-    });
+  var remain = arr.length % processes;
+  var per = (arr.length - remain) / processes;
+  var splitted = [];
+  while (arr.length) {
+    splitted.push(arr.splice(0, remain-- > 0 ? per + 1 : per));
   }
-
-  return normalizedFiles;
+  return splitted;
 };
 
 module.exports = Parallelizer;

--- a/lib/parallelizer.js
+++ b/lib/parallelizer.js
@@ -24,7 +24,7 @@ Parallelizer.prototype.kill = function() {
 
 Parallelizer.prototype.exec = function(task, target) {
   var cb = this.task_.async();
-  var splittedFilesSrc = this.getSplittedFilesSrc_(task, target);
+  var splittedFilesSrc = this.getSplittedFiles_(task, target);
 
   var spawnOptions;
   // Optionally log the task output
@@ -92,7 +92,7 @@ Parallelizer.prototype.getProcesses_ = function(task, target) {
   throw new Error('"processes" option not found');
 };
 
-Parallelizer.prototype.getSplittedFilesSrc_ = function(task, target) {
+Parallelizer.prototype.getSplittedFiles_ = function(task, target) {
   var files = this.getNormalizedFiles_(task, target);
   var processes = this.getProcesses_(task, target);
 

--- a/test/parallelizer_test.js
+++ b/test/parallelizer_test.js
@@ -40,7 +40,7 @@ describe('Parallelizer', function() {
     });
   });
 
-  describe('#getSplittedFilesSrc_', function() {
+  describe('#getSplittedFiles_', function() {
     var filesSrc, processes;
 
     beforeEach(function() {
@@ -56,7 +56,7 @@ describe('Parallelizer', function() {
       filesSrc = [{src: [1, 2, 3]}];
       processes = -1;
       expect(function() {
-        sut.getSplittedFilesSrc_(null, null);
+        sut.getSplittedFiles_(null, null);
       }).to.throwException();
     });
 
@@ -67,7 +67,7 @@ describe('Parallelizer', function() {
 
       it('returns empty array', function() {
         processes = 2;
-        expect(sut.getSplittedFilesSrc_(null, null)).to.be.empty();
+        expect(sut.getSplittedFiles_(null, null)).to.be.empty();
       });
     });
 
@@ -78,40 +78,40 @@ describe('Parallelizer', function() {
 
       it('splits into 0 []', function() {
         processes = 0;
-        expect(sut.getSplittedFilesSrc_(null, null)).to.be.empty();
+        expect(sut.getSplittedFiles_(null, null)).to.be.empty();
       });
 
       it('splits into 1 [4]', function() {
         processes = 1;
-        expect(sut.getSplittedFilesSrc_(null, null)).to.eql([
+        expect(sut.getSplittedFiles_(null, null)).to.eql([
           {src: [1, 2, 3, 4]}
         ]);
       });
 
       it('splits into 2 [2, 2]', function() {
         processes = 2;
-        expect(sut.getSplittedFilesSrc_(null, null)).to.eql([
+        expect(sut.getSplittedFiles_(null, null)).to.eql([
           {src: [1, 2]}, {src: [3, 4]}
         ]);
       });
 
       it('splits into 3 [2, 1, 1]', function() {
         processes = 3;
-        expect(sut.getSplittedFilesSrc_(null, null)).to.eql([
+        expect(sut.getSplittedFiles_(null, null)).to.eql([
           {src: [1, 2]}, {src: [3]}, {src: [4]}
         ]);
       });
 
       it('splits into 4 [1, 1, 1, 1]', function() {
         processes = 4;
-        expect(sut.getSplittedFilesSrc_(null, null)).to.eql([
+        expect(sut.getSplittedFiles_(null, null)).to.eql([
           {src: [1]}, {src: [2]}, {src: [3]}, {src: [4]}
         ]);
       });
 
       it('splits into 5 [1, 1, 1, 1]', function() {
         processes = 5;
-        expect(sut.getSplittedFilesSrc_(null, null)).to.eql([
+        expect(sut.getSplittedFiles_(null, null)).to.eql([
           {src: [1]}, {src: [2]}, {src: [3]}, {src: [4]}
         ]);
       });

--- a/test/parallelizer_test.js
+++ b/test/parallelizer_test.js
@@ -44,7 +44,7 @@ describe('Parallelizer', function() {
     var filesSrc, processes;
 
     beforeEach(function() {
-      sut.getNormalizedFilesSrc_ = function() {
+      sut.getNormalizedFiles_ = function() {
         return filesSrc;
       };
       sut.getProcesses_ = function() {
@@ -53,7 +53,7 @@ describe('Parallelizer', function() {
     });
 
     it('throws if "processes" option is negative', function() {
-      filesSrc = [1, 2, 3];
+      filesSrc = [{src: [1, 2, 3]}];
       processes = -1;
       expect(function() {
         sut.getSplittedFilesSrc_(null, null);
@@ -73,7 +73,7 @@ describe('Parallelizer', function() {
 
     describe('filesSrc has 4 items', function() {
       beforeEach(function() {
-        filesSrc = [1, 2, 3, 4];
+        filesSrc = [{src: [1, 2, 3, 4]}];
       });
 
       it('splits into 0 []', function() {
@@ -84,35 +84,35 @@ describe('Parallelizer', function() {
       it('splits into 1 [4]', function() {
         processes = 1;
         expect(sut.getSplittedFilesSrc_(null, null)).to.eql([
-          [1, 2, 3, 4]
+          {src: [1, 2, 3, 4]}
         ]);
       });
 
       it('splits into 2 [2, 2]', function() {
         processes = 2;
         expect(sut.getSplittedFilesSrc_(null, null)).to.eql([
-          [1, 2], [3, 4]
+          {src: [1, 2]}, {src: [3, 4]}
         ]);
       });
 
       it('splits into 3 [2, 1, 1]', function() {
         processes = 3;
         expect(sut.getSplittedFilesSrc_(null, null)).to.eql([
-          [1, 2], [3], [4]
+          {src: [1, 2]}, {src: [3]}, {src: [4]}
         ]);
       });
 
       it('splits into 4 [1, 1, 1, 1]', function() {
         processes = 4;
         expect(sut.getSplittedFilesSrc_(null, null)).to.eql([
-          [1], [2], [3], [4]
+          {src: [1]}, {src: [2]}, {src: [3]}, {src: [4]}
         ]);
       });
 
       it('splits into 5 [1, 1, 1, 1]', function() {
         processes = 5;
         expect(sut.getSplittedFilesSrc_(null, null)).to.eql([
-          [1], [2], [3], [4]
+          {src: [1]}, {src: [2]}, {src: [3]}, {src: [4]}
         ]);
       });
     });


### PR DESCRIPTION
Change internal file format from
```js
[
  {src: '1.js'},
  {src: '2.js'},
  {src: '3.js'}
]
```
to
```js
[
  {src: [
    '1.js',
    '2.js',
    '3.js'
  ]
]
```

Because grunt-gjslint spawns three processes for the previous format.